### PR TITLE
Only publicize the Assembly-CSharp.dll file

### DIFF
--- a/ExampleCWPlugin.csproj
+++ b/ExampleCWPlugin.csproj
@@ -10,7 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Reference Include="$(CWDir)\Content Warning_Data\Managed\*.dll" Private="false" Publicize="True"/>
+        <Reference Include="$(CWDir)\Content Warning_Data\Managed\*.dll" Exclude="$(CWDir)\Content Warning_Data\Managed\Assembly-CSharp.dll" Private="false"/>
+        <Reference Include="$(CWDir)\Content Warning_Data\Managed\Assembly-CSharp.dll" Publicize="true" Private="false"/>
     </ItemGroup>
 
     <!-- Use BepInEx's Assembly Publicizer to tell the compiler & IDE that every field, method, etc. is public, in the game assemblies. -->


### PR DESCRIPTION
Changes the publicization to only target Assembly-CSharp, fixing issues with other assemblies being publicized