### PR TITLE
Publicize by Assembly Name.

### DIFF
--- a/ExampleCWPlugin.csproj
+++ b/ExampleCWPlugin.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Reference Include="$(CWDir)\Content Warning_Data\Managed\*.dll" Exclude="$(CWDir)\Content Warning_Data\Managed\Assembly-CSharp.dll" Private="false"/>
-        <Reference Include="$(CWDir)\Content Warning_Data\Managed\Assembly-CSharp.dll" Publicize="true" Private="false"/>
+        <Reference Include="$(CWDir)\Content Warning_Data\Managed\*.dll" Private="false"/>
+        <Publicize Include="Assembly-CSharp"/>
     </ItemGroup>
 
     <!-- Use BepInEx's Assembly Publicizer to tell the compiler & IDE that every field, method, etc. is public, in the game assemblies. -->


### PR DESCRIPTION
Publicize by assembly name instead of excluding and including references.

Silly change but maybe it's worth accepting a PR for.